### PR TITLE
Fix index page rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,8 +5,7 @@ email: ""
 url: "https://louisbrion.com"
 
 theme: minima
-minima:
-  skin: dark
+show_excerpts: true
 
 plugins:
   - jekyll-feed

--- a/index.md
+++ b/index.md
@@ -1,3 +1,5 @@
 ---
 layout: home
 ---
+
+Posts will appear here as I write them.


### PR DESCRIPTION
Two fixes for the home page not rendering correctly.

**`_config.yml`** — Removes `minima: skin: dark`. GitHub Pages uses Minima 2.5.1; the `skin` feature is Minima 3.x only. On 2.5.1 this setting is ignored but is misleading. Also adds `show_excerpts: true` so post previews appear on the home page once you start writing.

**`index.md`** — Adds a one-line placeholder below the front matter. Minima's `home` layout renders an empty post list when there are no posts, making the page appear blank. This ensures there's always visible content.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzeYhsJRaM8d3oZ1Bk9YTy)_