### PR TITLE
Add jekyll-sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ show_excerpts: true
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-sitemap
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
Adds `jekyll-sitemap` to the plugins list in `_config.yml`. No Gemfile change needed — it's already bundled in the `github-pages` gem.

After merging, `/sitemap.xml` will be live and auto-updating on every build.

https://claude.ai/code/session_01GzeYhsJRaM8d3oZ1Bk9YTy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzeYhsJRaM8d3oZ1Bk9YTy)_