### PR TITLE
Add Lunr.js client-side search

### DIFF
--- a/search.json
+++ b/search.json
@@ -1,0 +1,14 @@
+---
+layout: null
+permalink: /search.json
+---
+[
+  {%- for post in site.posts -%}
+  {
+    "title": {{ post.title | jsonify }},
+    "url": {{ post.url | jsonify }},
+    "date": {{ post.date | date: "%B %-d, %Y" | jsonify }},
+    "content": {{ post.content | strip_html | truncate: 5000 | jsonify }}
+  }{% unless forloop.last %},{% endunless %}
+  {%- endfor -%}
+]

--- a/search.md
+++ b/search.md
@@ -1,0 +1,39 @@
+---
+layout: page
+title: Search
+permalink: /search/
+---
+
+<input type="text" id="search-input" placeholder="Search posts…" autocomplete="off" style="width:100%;padding:0.5em;font-size:1em;box-sizing:border-box;margin-bottom:1em;">
+<ul id="search-results"></ul>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.9/lunr.min.js"></script>
+<script>
+(function () {
+  var idx, posts;
+
+  fetch('/search.json')
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      posts = data;
+      idx = lunr(function () {
+        this.ref('url');
+        this.field('title', { boost: 10 });
+        this.field('content');
+        data.forEach(function (doc) { this.add(doc); }, this);
+      });
+    });
+
+  document.getElementById('search-input').addEventListener('input', function () {
+    var q = this.value.trim();
+    var el = document.getElementById('search-results');
+    if (!q || !idx) { el.innerHTML = ''; return; }
+    var results = idx.search(q);
+    if (!results.length) { el.innerHTML = '<li>No results.</li>'; return; }
+    el.innerHTML = results.map(function (r) {
+      var p = posts.find(function (d) { return d.url === r.ref; });
+      return '<li><a href="' + p.url + '">' + p.title + '</a><br><small>' + p.date + '</small></li>';
+    }).join('');
+  });
+}());
+</script>


### PR DESCRIPTION
Adds client-side full-text search via Lunr.js.

Two files:
- `search.json` — Jekyll/Liquid template that builds a JSON index of all posts at build time (title, URL, date, stripped content). Lives at `/search.json`.
- `search.md` — Search page at `/search/`. Loads the index on page load, queries Lunr on each keystroke, renders matching post titles and dates as links.

No plugin required — the index is generated with Liquid templating, which works within GitHub Pages' constraints. Lunr is loaded from CDN. The index regenerates automatically on every build alongside the sitemap.

Minima will add a "Search" link to the site nav automatically since `search.md` uses `layout: page`.

https://claude.ai/code/session_01GzeYhsJRaM8d3oZ1Bk9YTy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzeYhsJRaM8d3oZ1Bk9YTy)_